### PR TITLE
Matrixify Q before comparison

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,7 +28,7 @@ end
 	@test FNC.lsqrfact(A,b) ≈ A\b
 	Q,R = qr(A)
 	QQ,RR = FNC.qrfact(A)
-	@test Q ≈ QQ
+	@test Matrix(Q) ≈ QQ
 	@test R ≈ RR[1:3,:]
 end
 


### PR DESCRIPTION
This came up in a nanosoldier run in https://github.com/JuliaLang/julia/pull/46196. Independently from that PR, I noticed usage of a `qr(A).Q` object in a matrix comparison. In real code, this operation would be very slow due to slow `getindex` for `AbstractQ` objects. The proposed change doesn't change anything functionally, but avoids potential issues in case https://github.com/JuliaLang/julia/pull/46196 gets accepted.